### PR TITLE
Remove AWSCore from project.json

### DIFF
--- a/Project/project.json
+++ b/Project/project.json
@@ -29,7 +29,6 @@
         "Environment",
         "UserInterface",
         "Weapons",
-        "AWSCore",
         "Atom",
         "AudioSystem",
         "CameraFramework",


### PR DESCRIPTION
The gem is not needed and cause compilation issue now that it is not in the O3DE repo